### PR TITLE
Initial accounts request sent over secure API

### DIFF
--- a/background/loadScripts.js
+++ b/background/loadScripts.js
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import { UI, getRetryTimeout } from '../shared';
+import { UI, EV_BAR_CODE, getRetryTimeout } from '../shared';
 
 class VersionMismatch extends Error {
   isVersionMismatch = true;
@@ -30,7 +30,7 @@ export default function loadScripts (port) {
   }
 
   function retry (msg) {
-    if (msg.type !== 'parity.bar.code') {
+    if (msg.type !== EV_BAR_CODE) {
       return;
     }
 

--- a/background/transport.js
+++ b/background/transport.js
@@ -17,7 +17,7 @@
 /* global chrome */
 
 import Ws from './ws';
-import { UI, TRANSPORT_UNINITIALIZED, getRetryTimeout } from '../shared';
+import { UI, TRANSPORT_UNINITIALIZED, EV_WEB3_ACCOUNTS_REQUEST, EV_TOKEN, getRetryTimeout } from '../shared';
 
 let openedTabId = null;
 let transport = null;
@@ -68,7 +68,7 @@ function newTransport (token) {
 chrome.runtime.onMessage.addListener((request, sender, callback) => {
   const isTransportReady = transport && transport.isConnected;
 
-  if (request.type === 'parity.web3.accounts.request') {
+  if (request.type === EV_WEB3_ACCOUNTS_REQUEST) {
     if (!isTransportReady) {
       return callback({
         err: TRANSPORT_UNINITIALIZED
@@ -97,7 +97,7 @@ chrome.runtime.onMessage.addListener((request, sender, callback) => {
       }));
   }
 
-  if (request.type !== 'parity.token') {
+  if (request.type !== EV_TOKEN) {
     return;
   }
 

--- a/shared/index.js
+++ b/shared/index.js
@@ -1,7 +1,14 @@
 export const TRANSPORT_UNINITIALIZED = 'Transport uninitialized';
 export const UI = '127.0.0.1:8180';
 export const DAPPS = '127.0.0.1:8080';
-export const ACCOUNTS_REQUEST = 'parity.background.accounts';
+
+export const EV_WEB3_REQUEST = 'parity.web3.request';
+export const EV_WEB3_RESPONSE = 'parity.web3.response';
+export const EV_WEB3_ACCOUNTS_REQUEST = 'parity.web3.accounts.request';
+export const EV_WEB3_ACCOUNTS_RESPONSE = 'parity.web3.accounts.response';
+export const EV_TOKEN = 'parity.token';
+export const EV_SIGNER_BAR = 'parity.signer.bar';
+export const EV_BAR_CODE = 'parity.signer.bar.code';
 
 /**
  * Exponential Timeout for Retries

--- a/web3/secureTransport.js
+++ b/web3/secureTransport.js
@@ -3,7 +3,7 @@
 /*
  * NOTE: Executed in extension context
  */
-import { TRANSPORT_UNINITIALIZED } from '../shared';
+import { TRANSPORT_UNINITIALIZED, EV_WEB3_REQUEST, EV_SIGNER_BAR, EV_BAR_CODE } from '../shared';
 
 /**
  * Creates a secureTransport, that can be used by injected ParityBar
@@ -46,7 +46,7 @@ export function createSecureTransport () {
 
         port.postMessage({
           id,
-          type: 'parity.web3.request',
+          type: EV_WEB3_REQUEST,
           payload: request
         });
       });
@@ -68,7 +68,7 @@ export function handleResizeEvents () {
   document.body.addEventListener('parity.bar.visibility', (ev) => {
     document.querySelector('#container > div > div').style.maxHeight = '100vh';
     window.parent.postMessage({
-      type: 'parity.signer.bar',
+      type: EV_SIGNER_BAR,
       opened: ev.detail.opened
     }, '*');
   });
@@ -107,7 +107,7 @@ export function loadScripts () {
   });
 
   port.postMessage({
-    type: 'parity.bar.code'
+    type: EV_BAR_CODE
   });
 }
 


### PR DESCRIPTION
Changing the initial request for accounts to go through secureApi instead of standard dapps port.
Parity keeps track of the dapps, we don't want every website to be registered as visited by Parity, hence we use `parity_getDappsAddresses` instead of `eth_accounts`.