### PR TITLE
Better positioning of badges

### DIFF
--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -123,7 +123,7 @@ export default class Augmentor {
         styles.container
           .split(' ')
           .forEach((className) => {
-            node.classList.add(className);
+            // node.classList.add(className);
           });
 
         // node.appendChild(augmentedIcon);
@@ -132,8 +132,10 @@ export default class Augmentor {
         placeholder.textContent = '|';
         placeholder.style.visibility = 'hidden';
         placeholder.style.width = '0';
-        node.insertBefore(augmentedIcon, node.childNodes[0]);
-        node.insertBefore(placeholder, augmentedIcon);
+
+        // node.insertBefore(augmentedIcon, node.childNodes[0]);
+        // node.insertBefore(placeholder, augmentedIcon);
+        node.insertAdjacentElement('beforebegin', augmentedIcon);
       })
       .catch((error) => {
         console.error('augmenting node', key, error);

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -119,22 +119,6 @@ export default class Augmentor {
           node.style.height = `${height}px`;
         }
 
-        // Add the right classe(s)
-        styles.container
-          .split(' ')
-          .forEach((className) => {
-            // node.classList.add(className);
-          });
-
-        // node.appendChild(augmentedIcon);
-        // Add the augmented icon
-        const placeholder = document.createElement('span');
-        placeholder.textContent = '|';
-        placeholder.style.visibility = 'hidden';
-        placeholder.style.width = '0';
-
-        // node.insertBefore(augmentedIcon, node.childNodes[0]);
-        // node.insertBefore(placeholder, augmentedIcon);
         node.insertAdjacentElement('beforebegin', augmentedIcon);
       })
       .catch((error) => {

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -22,8 +22,6 @@ import { AugmentedIcon } from './components';
 import Runner from './runner';
 import { FETCH_IMAGE } from '../background/processor';
 
-import styles from './styles.css';
-
 export const AUGMENTED_NODE_ATTRIBUTE = 'data-parity-touched';
 
 export default class Augmentor {

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -114,7 +114,7 @@ export default class Augmentor {
 
         // Set the proper height if it has been modified
         if (height !== iconHeight) {
-          node.style.height = `${height}px`;
+          augmentedIcon.style.top = (height - iconHeight) / 2 + 'px';
         }
 
         node.insertAdjacentElement('beforebegin', augmentedIcon);

--- a/content/components/accountCard.css
+++ b/content/components/accountCard.css
@@ -34,7 +34,7 @@
   opacity: 0;
   z-index: -1;
 
-  transform-origin: top;
+  transform-origin: top left;
 
   flex-direction: column;
   align-items: flex-start;

--- a/content/components/accountCard.js
+++ b/content/components/accountCard.js
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+import classnames from 'classnames';
 import { bind } from 'decko';
 import { noop } from 'lodash';
 import { h, Component } from 'preact';
@@ -54,11 +55,10 @@ export default class AccountCard extends Component {
     const { address, badges, name, size, tokens } = this.props;
     const { open, style } = this.state;
 
-    const mainClasses = [ styles.card ];
-
-    if (open) {
-      mainClasses.push(styles.open);
-    }
+    const className = classnames({
+      [styles.card]: true,
+      [styles.open]: open
+    });
 
     const containerStyle = {
       ...style,
@@ -68,7 +68,7 @@ export default class AccountCard extends Component {
 
     return (
       <span
-        className={ mainClasses.join(' ') }
+        className={ className }
         ref={ this.handleRef }
         style={ containerStyle }
       >

--- a/content/components/accountCard.js
+++ b/content/components/accountCard.js
@@ -52,7 +52,7 @@ export default class AccountCard extends Component {
   }
 
   render () {
-    const { address, badges, name, tokens } = this.props;
+    const { address, badges, name, size, tokens } = this.props;
     const { open, style } = this.state;
 
     const mainClasses = [ styles.card ];
@@ -61,11 +61,17 @@ export default class AccountCard extends Component {
       mainClasses.push(styles.open);
     }
 
+    const containerStyle = {
+      ...style,
+      top: size / 2,
+      left: size / 2
+    };
+
     return (
       <span
         className={ mainClasses.join(' ') }
         ref={ this.handleRef }
-        style={ style }
+        style={ containerStyle }
       >
         <span className={ styles.header }>
           <IdentityIcon

--- a/content/components/accountCard.js
+++ b/content/components/accountCard.js
@@ -112,19 +112,31 @@ export default class AccountCard extends Component {
   }
 
   renderTokens (tokens) {
-    return tokens.map((token) => {
-      const { balance, title, TLA, src } = token;
+    return tokens
+      .sort((tokenA, tokenB) => {
+        if (tokenA.TLA.toLowerCase() === 'eth') {
+          return -1;
+        }
 
-      return (
-        <Token
-          badge={ { src, size: 32 } }
-          balance={ balance }
-          key={ TLA }
-          name={ TLA }
-          title={ title }
-        />
-      );
-    });
+        if (tokenB.TLA.toLowerCase() === 'eth') {
+          return 1;
+        }
+
+        return tokenA.TLA.localeCompare(tokenB.TLA);
+      })
+      .map((token) => {
+        const { balance, title, TLA, src } = token;
+
+        return (
+          <Token
+            badge={ { src, size: 32 } }
+            balance={ balance }
+            key={ TLA }
+            name={ TLA }
+            title={ title }
+          />
+        );
+      });
   }
 
   renderBadges (badges) {

--- a/content/components/augmentedIcon.css
+++ b/content/components/augmentedIcon.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-.badges, .icons {
+.badges {
   composes: transition from '../styles.css';
 
   display: inline-flex;
@@ -24,10 +24,20 @@
 }
 
 .icons {
-  flex-direction: column;
-  margin-right: 5px;
+  composes: transition from '../styles.css';
+
   font-family: 'Roboto', sans-serif;
   font-weight: 300;
+
+  position: absolute;
+  top: 0;
+  left: 0;
+
+  z-index: -1;
+
+  &.open, &.hover {
+    z-index: 999;
+  }
 
   &:hover {
     cursor: pointer;
@@ -42,11 +52,18 @@
   composes: transition from '../styles.css';
 
   display: inline-block;
+  vertical-align: text-bottom;
+
   z-index: 10;
   opacity: 0.75;
+  margin-right: 5px;
 
   &.hover {
     opacity: 1;
+  }
+
+  &:hover {
+    cursor: pointer;
   }
 }
 

--- a/content/components/augmentedIcon.css
+++ b/content/components/augmentedIcon.css
@@ -53,6 +53,7 @@
 
   display: inline-block;
   vertical-align: text-top;
+  position: relative;
 
   z-index: 10;
   opacity: 0.75;
@@ -65,6 +66,11 @@
   &:hover {
     cursor: pointer;
   }
+}
+
+.icon {
+  position: absolute;
+  top: 0;
 }
 
 .badges {

--- a/content/components/augmentedIcon.css
+++ b/content/components/augmentedIcon.css
@@ -52,7 +52,7 @@
   composes: transition from '../styles.css';
 
   display: inline-block;
-  vertical-align: text-bottom;
+  vertical-align: text-top;
 
   z-index: 10;
   opacity: 0.75;

--- a/content/components/augmentedIcon.js
+++ b/content/components/augmentedIcon.js
@@ -78,6 +78,7 @@ export default class AugmentedIcon extends Component {
       >
         <IdentityIcon
           address={ address }
+          className={ styles.icon }
           ref={ this.handleIconRef }
           size={ height }
         />

--- a/content/components/augmentedIcon.js
+++ b/content/components/augmentedIcon.js
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+import classnames from 'classnames';
 import { bind } from 'decko';
 import { debounce } from 'lodash';
 import { h, Component } from 'preact';
@@ -56,21 +57,20 @@ export default class AugmentedIcon extends Component {
     const { address, badges, height, name, tokens } = this.props;
     const { badgesStyle, containerStyle, hover, open } = this.state;
 
-    const iconClasses = [ styles.iconContainer ];
-    const containerClasses = [ styles.icons ];
+    const iconClass = classnames({
+      [styles.iconContainer]: true,
+      [styles.hover]: hover
+    });
 
-    if (hover) {
-      iconClasses.push(styles.hover);
-      containerClasses.push(styles.hover);
-    }
-
-    if (open) {
-      containerClasses.push(styles.open);
-    }
+    const containerClass = classnames({
+      [styles.icons]: true,
+      [styles.hover]: hover,
+      [styles.open]: open
+    });
 
     return (
       <span
-        className={ iconClasses.join(' ') }
+        className={ iconClass }
         onClick={ this.handleClick }
         onMousemove={ this.handleMousemove }
         style={ { height: height, width: height } }
@@ -84,7 +84,7 @@ export default class AugmentedIcon extends Component {
 
         <Portal into='body'>
           <div
-            className={ containerClasses.join(' ') }
+            className={ containerClass }
             onClick={ this.handleClick }
             style={ containerStyle }
           >
@@ -330,15 +330,14 @@ class Badges extends Component {
     const { badges, size, style = {} } = this.props;
     const { show } = this.state;
 
-    const classes = [ styles.badges ];
-
-    if (show) {
-      classes.push(styles.hover);
-    }
+    const className = classnames({
+      [styles.badges]: true,
+      [styles.hover]: show
+    });
 
     return (
       <span
-        className={ classes.join(' ') }
+        className={ className }
         style={ style }
       >
         { this.renderBadges(badges, size) }

--- a/content/components/augmentedIcon.js
+++ b/content/components/augmentedIcon.js
@@ -301,12 +301,12 @@ export default class AugmentedIcon extends Component {
       return;
     }
 
-    const bodyRect = document.body.getBoundingClientRect();
+    const { scrollTop, scrollLeft } = document.body;
     const elemRect = iconElement.base.getBoundingClientRect();
 
     const nextStyle = {
-      top: elemRect.top - bodyRect.top + elemRect.height,
-      left: elemRect.left - bodyRect.left + elemRect.width / 2
+      top: elemRect.top + scrollTop,
+      left: elemRect.left + scrollLeft
     };
 
     this.setState({ containerStyle: nextStyle });

--- a/content/components/badge.js
+++ b/content/components/badge.js
@@ -20,11 +20,11 @@ import { h } from 'preact';
 import styles from './badge.css';
 
 const Badge = ({ children, ...props }) => {
-  const { size = 16, src, style = {}, title } = props;
+  const { className = '', size = 16, src, style = {}, title } = props;
 
   return (
     <img
-      className={ styles.badge }
+      className={ [ styles.badge, className ].join(' ') }
       src={ src }
       style={ { height: size, width: size, ...style } }
       title={ title }

--- a/content/components/badge.js
+++ b/content/components/badge.js
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+import classnames from 'classnames';
 import { h } from 'preact';
 
 import styles from './badge.css';
@@ -21,9 +22,11 @@ import styles from './badge.css';
 const Badge = ({ children, ...props }) => {
   const { className = '', size = 16, src, style = {}, title } = props;
 
+  const imgClassName = classnames(styles.badge, className);
+
   return (
     <img
-      className={ [ styles.badge, className ].join(' ') }
+      className={ imgClassName }
       src={ src }
       style={ { height: size, width: size, ...style } }
       title={ title }

--- a/content/components/identityIcon.js
+++ b/content/components/identityIcon.js
@@ -24,12 +24,13 @@ import Badge from './badge';
 export default class IdentityIcon extends Component {
 
   render () {
-    const { address, size = 8, style = {} } = this.props;
+    const { address, className = '', size = 8, style = {} } = this.props;
 
     const src = this.getBlockie(address, size);
 
     return (
       <Badge
+        className={ className }
         size={ size }
         src={ src }
         style={ style }

--- a/content/components/token.js
+++ b/content/components/token.js
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+import classnames from 'classnames';
 import { h, Component } from 'preact';
 
 import Badge from './badge';
@@ -26,11 +27,10 @@ export default class Token extends Component {
     const { badge, balance, name, title } = this.props;
     const { size, src } = badge;
 
-    const nameClasses = [ styles.tla ];
-
-    if (!balance) {
-      nameClasses.push(styles['no-value']);
-    }
+    const nameClass = classnames({
+      [styles.tla]: true,
+      [styles['no-value']]: !balance
+    });
 
     return (
       <span
@@ -46,7 +46,7 @@ export default class Token extends Component {
         <span className={ styles.balance }>
           { this.renderBalance(balance) }
 
-          <span className={ nameClasses.join(' ') }>
+          <span className={ nameClass }>
             { name }
           </span>
         </span>

--- a/content/util/style.js
+++ b/content/util/style.js
@@ -19,15 +19,15 @@ export function positionToStyle (options = {}) {
   const { x, y } = position;
 
   // default to center
-  let X = 0;
+  let X = '-50%';
   let Y = `-50%`;
 
   if (x === 'left') {
-    X = `-50%`;
+    X = `-100%`;
   }
 
   if (x === 'right') {
-    X = `50%`;
+    X = `0`;
   }
 
   if (y === 'top') {

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "blockies": "0.0.2",
+    "classnames": "^2.2.5",
     "decko": "^1.1.3",
     "eventemitter3": "^2.0.2",
     "isomorphic-fetch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -57,12 +57,13 @@
     "webpack": "^2.2.0"
   },
   "dependencies": {
-    "eventemitter3": "^2.0.2",
     "blockies": "0.0.2",
     "decko": "^1.1.3",
+    "eventemitter3": "^2.0.2",
     "isomorphic-fetch": "^2.2.1",
     "js-sha3": "^0.5.7",
     "lodash": "^4.17.4",
-    "preact": "^7.1.0"
+    "preact": "^7.1.0",
+    "preact-portal": "^1.1.1"
   }
 }


### PR DESCRIPTION
Less intrusive badges positioning by only adding the image next to the detected email/handle/etc.
The badges and AccountCard are added at the root of the document, and are positioned correctly when needed.
Fixes some hidden overflow issues on some website (eg. Facebook)

Also puts the ETH tokens in first position.