### PR TITLE
Refactoring of extractions // Warn users for untrusted matches

### DIFF
--- a/background/processor.js
+++ b/background/processor.js
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import { uniq } from 'lodash';
-
 import Extractions from '../content/extractions';
 import Lookup from './lookup';
 

--- a/content/accounts.js
+++ b/content/accounts.js
@@ -1,0 +1,81 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { PROCESS_EXTRACTIONS, FETCH_ADDRESS } from '../background/processor';
+import Extractions from './extractions';
+import Runner from './runner';
+
+let instance = null;
+
+export default class Accounts {
+
+  accounts = {};
+
+  static get () {
+    if (!instance) {
+      instance = new Accounts();
+    }
+
+    return instance;
+  }
+
+  static find (address) {
+    const self = Accounts.get();
+
+    return self.accounts[address];
+  }
+
+  static fetch (address) {
+    const self = Accounts.get();
+
+    return self.fetchAddress(address);
+  }
+
+  static processExtractions (extractions) {
+    const self = Accounts.get();
+
+    return Runner.execute(PROCESS_EXTRACTIONS, extractions.toObject())
+      .then((results) => {
+        const nextExtractions = Extractions.fromObject(results);
+        const addresses = nextExtractions.addresses;
+
+        // Replace the extractions with the new ones
+        extractions.replaceWith(nextExtractions);
+
+        // Fetch addresses info
+        return self.fetchAddresses(addresses);
+      });
+  }
+
+  fetchAddresses (addresses = []) {
+    const promises = addresses.map((address) => this.fetchAddress(address));
+
+    return Promise.all(promises);
+  }
+
+  fetchAddress (address) {
+    if (!this.accounts[address]) {
+      this.accounts[address] = Runner.execute(FETCH_ADDRESS, address)
+        .then((data) => {
+          this.accounts[address] = data;
+          return data;
+        });
+    }
+
+    return Promise.resolve(this.accounts[address]);
+  }
+
+}

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -61,7 +61,7 @@ export default class Augmentor {
         .apply(node.childNodes)
         .find((node) => node.textContent.includes(value));
 
-      const safeNode  = Augmentor.getSafeNode(value, textNode);
+      const safeNode = Augmentor.getSafeNode(value, textNode);
       return safeNode && safeNode.node;
     }
 

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -17,7 +17,7 @@
 import { h, render } from 'preact';
 
 import { AugmentedIcon } from './components';
-import { EXTRACT_TYPE_HANDLE } from './extraction';
+import { EXTRACT_TYPE_HANDLE, EXTRACT_TYPE_GITHUB } from './extraction';
 import Accounts from './accounts';
 import Runner from './runner';
 import { FETCH_IMAGE } from '../background/processor';
@@ -119,12 +119,18 @@ export default class Augmentor {
         const iconHeight = Math.min(height, 20);
         const safe = extraction.type !== EXTRACT_TYPE_HANDLE;
 
+        // If from Github, display the Github handle if
+        // no name linked
+        const displayName = extraction.type === EXTRACT_TYPE_GITHUB
+          ? name || extraction.match
+          : name;
+
         const augmentedIcon = render((
           <AugmentedIcon
             address={ address }
             badges={ badges }
             height={ iconHeight }
-            name={ name }
+            name={ displayName }
             safe={ safe }
             tokens={ tokens }
           />

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -15,7 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import { h, render } from 'preact';
-/** @jsx h */
 
 import { AugmentedIcon } from './components';
 
@@ -121,7 +120,7 @@ export default class Augmentor {
         node.insertAdjacentElement('beforebegin', augmentedIcon);
       })
       .catch((error) => {
-        console.error('augmenting node', key, error);
+        console.error('augmenting node', extraction.toObject(), error);
       });
   }
 

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -19,6 +19,7 @@ import { h, render } from 'preact';
 
 import { AugmentedIcon } from './components';
 
+import Accounts from './accounts';
 import Runner from './runner';
 import { FETCH_IMAGE } from '../background/processor';
 
@@ -29,7 +30,7 @@ export default class Augmentor {
   static getSafeNode (value, node) {
     const text = node.textContent || '';
 
-    // Safe Node is if the node which inner text is only the value
+    // Already the safe node if the inner text is only the value
     if (text.trim() === value) {
       return node;
     }
@@ -76,7 +77,7 @@ export default class Augmentor {
     return safeNode;
   }
 
-  static augmentNode (key, node, resolved = {}) {
+  static augmentNode (extraction, node) {
     if (!node || node.hasAttribute(AUGMENTED_NODE_ATTRIBUTE)) {
       return;
     }
@@ -84,7 +85,7 @@ export default class Augmentor {
     const rawText = node.textContent;
     const text = (rawText || '').trim();
 
-    const data = resolved[key];
+    const data = Accounts.find(extraction.address);
     node.setAttribute(AUGMENTED_NODE_ATTRIBUTE, true);
 
     // Don't augment empty nodes

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -119,20 +119,26 @@ export default class Augmentor {
         // Compute the height of the text, which should be the
         // height of the element minus the paddings
         const { height = 16 } = node.getBoundingClientRect();
-        const { paddingTop, paddingBottom } = window.getComputedStyle(node);
+        const { lineHeight, paddingTop, paddingBottom } = window.getComputedStyle(node);
 
-        let padding = 0;
+        let padTop = 0;
+        let padBottom = 0;
+        let nodeLineHeight = height;
         const pxRegex = /^(\d+)px$/i;
 
         if (pxRegex.test(paddingTop)) {
-          padding += parseFloat(pxRegex.exec(paddingTop)[1]);
+          padTop = parseFloat(pxRegex.exec(paddingTop)[1]);
         }
 
         if (pxRegex.test(paddingBottom)) {
-          padding += parseFloat(pxRegex.exec(paddingBottom)[1]);
+          padBottom = parseFloat(pxRegex.exec(paddingBottom)[1]);
         }
 
-        const nodeHeight = height - padding;
+        if (pxRegex.test(lineHeight)) {
+          nodeLineHeight = parseFloat(pxRegex.exec(lineHeight)[1]);
+        }
+
+        const nodeHeight = height - padTop - padBottom;
         const iconHeight = Math.min(nodeHeight, 20);
 
         const safe = extraction.type !== EXTRACT_TYPE_HANDLE;
@@ -155,9 +161,7 @@ export default class Augmentor {
         ));
 
         // Set the proper height if it has been modified
-        if (nodeHeight !== iconHeight) {
-          augmentedIcon.style.top = (nodeHeight - iconHeight) / 2 + 'px';
-        }
+        augmentedIcon.style.top = ((nodeLineHeight - iconHeight) / 2 - padTop) + 'px';
 
         node.insertAdjacentElement('afterbegin', augmentedIcon);
       })

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -115,8 +115,26 @@ export default class Augmentor {
     return Augmentor.fetchImages(data)
       .then(([ badges, tokens ]) => {
         const { address, name } = data;
+
+        // Compute the height of the text, which should be the
+        // height of the element minus the paddings
         const { height = 16 } = node.getBoundingClientRect();
-        const iconHeight = Math.min(height, 20);
+        const { paddingTop, paddingBottom } = window.getComputedStyle(node);
+
+        let padding = 0;
+        const pxRegex = /^(\d+)px$/i;
+
+        if (pxRegex.test(paddingTop)) {
+          padding += parseFloat(pxRegex.exec(paddingTop)[1]);
+        }
+
+        if (pxRegex.test(paddingBottom)) {
+          padding += parseFloat(pxRegex.exec(paddingBottom)[1]);
+        }
+
+        const nodeHeight = height - padding;
+        const iconHeight = Math.min(nodeHeight, 20);
+
         const safe = extraction.type !== EXTRACT_TYPE_HANDLE;
 
         // If from Github, display the Github handle if
@@ -137,11 +155,11 @@ export default class Augmentor {
         ));
 
         // Set the proper height if it has been modified
-        if (height !== iconHeight) {
-          augmentedIcon.style.top = (height - iconHeight) / 2 + 'px';
+        if (nodeHeight !== iconHeight) {
+          augmentedIcon.style.top = (nodeHeight - iconHeight) / 2 + 'px';
         }
 
-        node.insertAdjacentElement('beforebegin', augmentedIcon);
+        node.insertAdjacentElement('afterbegin', augmentedIcon);
       })
       .catch((error) => {
         console.error('augmenting node', extraction.toObject(), error);

--- a/content/augmentor.js
+++ b/content/augmentor.js
@@ -17,7 +17,7 @@
 import { h, render } from 'preact';
 
 import { AugmentedIcon } from './components';
-
+import { EXTRACT_TYPE_HANDLE } from './extraction';
 import Accounts from './accounts';
 import Runner from './runner';
 import { FETCH_IMAGE } from '../background/processor';
@@ -117,6 +117,7 @@ export default class Augmentor {
         const { address, name } = data;
         const { height = 16 } = node.getBoundingClientRect();
         const iconHeight = Math.min(height, 20);
+        const safe = extraction.type !== EXTRACT_TYPE_HANDLE;
 
         const augmentedIcon = render((
           <AugmentedIcon
@@ -124,6 +125,7 @@ export default class Augmentor {
             badges={ badges }
             height={ iconHeight }
             name={ name }
+            safe={ safe }
             tokens={ tokens }
           />
         ));

--- a/content/components/accountCard.css
+++ b/content/components/accountCard.css
@@ -84,3 +84,14 @@
     }
   }
 }
+
+.warning {
+  margin: 0.5em 0;
+  font-size: 0.85rem;
+  text-align: justify;
+
+  code {
+    font-family: monospace !important;
+    font-size: 1rem;
+  }
+}

--- a/content/components/accountCard.css
+++ b/content/components/accountCard.css
@@ -15,12 +15,16 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+@import "../styles.css";
+
 .container {
   position: relative;
 }
 
 .card, .tokens {
-  composes: transition from '../styles.css';
+  transition-property: var(--transition-property);
+  transition-duration: var(--transition-duration);
+  transition-timing-function: var(--transition-timing-function);
 
   display: inline-flex;
   flex-direction: row;
@@ -43,6 +47,12 @@
   color: rgb(200, 200, 200);
 
   padding: 0.75em 1em;
+
+  * {
+    font-family: 'Roboto', sans-serif !important;
+    font-weight: 300 !important;
+    color: white !important;
+  }
 
   .address {
     cursor: text;

--- a/content/components/accountCard.js
+++ b/content/components/accountCard.js
@@ -52,7 +52,7 @@ export default class AccountCard extends Component {
   }
 
   render () {
-    const { address, badges, name, size, tokens } = this.props;
+    const { address, badges, name, safe, size, tokens } = this.props;
     const { open, style } = this.state;
 
     const className = classnames({
@@ -85,6 +85,8 @@ export default class AccountCard extends Component {
             { this.renderAddress(address) }
           </span>
         </span>
+
+        { this.renderWarning(safe, name) }
 
         <span className={ styles.tokens }>
           { this.renderTokens(tokens) }
@@ -151,6 +153,20 @@ export default class AccountCard extends Component {
         />
       );
     });
+  }
+
+  renderWarning (safe, name) {
+    if (safe) {
+      return null;
+    }
+
+    return (
+      <p className={ styles.warning }>
+        This account have been matched against the
+        Registry record <code>{ name }</code>.
+        It have not been verified and could be a false positive.
+      </p>
+    );
   }
 
   clearClick () {

--- a/content/components/augmentedIcon.css
+++ b/content/components/augmentedIcon.css
@@ -48,6 +48,10 @@
   position: absolute;
 }
 
+.unsafe {
+  filter: grayscale(100%);
+}
+
 .iconContainer {
   composes: transition from '../styles.css';
 
@@ -58,6 +62,11 @@
   z-index: 10;
   opacity: 0.75;
   margin-right: 5px;
+
+  &.unsafe {
+    filter: grayscale(100%);
+    opacity: 0.5;
+  }
 
   &.hover {
     opacity: 1;

--- a/content/components/augmentedIcon.css
+++ b/content/components/augmentedIcon.css
@@ -42,7 +42,7 @@
     z-index: 999;
   }
 
-  &:hover {
+  &:hover, *:hover {
     cursor: pointer;
   }
 }
@@ -64,7 +64,7 @@
   padding: 0 !important;
   margin: 0 5px 0 0 !important;
 
-  vertical-align: text-top !important;
+  vertical-align: top !important;
   position: relative !important;
   text-align: initial !important;
 
@@ -81,7 +81,7 @@
     opacity: 1;
   }
 
-  &:hover {
+  &:hover, *:hover {
     cursor: pointer;
   }
 }

--- a/content/components/augmentedIcon.css
+++ b/content/components/augmentedIcon.css
@@ -15,8 +15,12 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+@import "../styles.css";
+
 .badges {
-  composes: transition from '../styles.css';
+  transition-property: var(--transition-property);
+  transition-duration: var(--transition-duration);
+  transition-timing-function: var(--transition-timing-function);
 
   display: inline-flex;
   flex-direction: row;
@@ -24,10 +28,9 @@
 }
 
 .icons {
-  composes: transition from '../styles.css';
-
-  font-family: 'Roboto', sans-serif;
-  font-weight: 300;
+  transition-property: var(--transition-property);
+  transition-duration: var(--transition-duration);
+  transition-timing-function: var(--transition-timing-function);
 
   position: absolute;
   top: 0;
@@ -53,11 +56,17 @@
 }
 
 .iconContainer {
-  composes: transition from '../styles.css';
+  transition-property: var(--transition-property);
+  transition-duration: var(--transition-duration);
+  transition-timing-function: var(--transition-timing-function);
 
-  display: inline-block;
-  vertical-align: text-top;
-  position: relative;
+  display: inline-block !important;
+  padding: 0 !important;
+  margin: 0 5px 0 0 !important;
+
+  vertical-align: text-top !important;
+  position: relative !important;
+  text-align: initial !important;
 
   z-index: 10;
   opacity: 0.75;

--- a/content/components/augmentedIcon.js
+++ b/content/components/augmentedIcon.js
@@ -112,6 +112,7 @@ export default class AugmentedIcon extends Component {
               badges={ badges }
               name={ name }
               open={ open }
+              safe={ safe }
               size={ height }
               tokens={ tokens }
 

--- a/content/components/augmentedIcon.js
+++ b/content/components/augmentedIcon.js
@@ -54,37 +54,43 @@ export default class AugmentedIcon extends Component {
   }
 
   render () {
-    const { address, badges, height, name, tokens } = this.props;
+    const { address, badges, height, name, safe, tokens } = this.props;
     const { badgesStyle, containerStyle, hover, open } = this.state;
 
-    const iconClass = classnames({
+    const containerClass = classnames({
       [styles.iconContainer]: true,
-      [styles.hover]: hover
+      [styles.hover]: hover,
+      [styles.unsafe]: !safe
     });
 
-    const containerClass = classnames({
+    const contentClass = classnames({
       [styles.icons]: true,
       [styles.hover]: hover,
-      [styles.open]: open
+      [styles.open]: open,
+      [styles.unsafe]: !safe
+    });
+
+    const iconClass = classnames({
+      [styles.icon]: true
     });
 
     return (
       <span
-        className={ iconClass }
+        className={ containerClass }
         onClick={ this.handleClick }
         onMousemove={ this.handleMousemove }
         style={ { height: height, width: height } }
       >
         <IdentityIcon
           address={ address }
-          className={ styles.icon }
+          className={ iconClass }
           ref={ this.handleIconRef }
           size={ height }
         />
 
         <Portal into='body'>
           <div
-            className={ containerClass }
+            className={ contentClass }
             onClick={ this.handleClick }
             style={ containerStyle }
           >

--- a/content/components/identityIcon.js
+++ b/content/components/identityIcon.js
@@ -25,7 +25,9 @@ export default class IdentityIcon extends Component {
   render () {
     const { address, className = '', size = 8, style = {} } = this.props;
 
-    const src = this.getBlockie(address, size);
+    // Use a key for memoize
+    const key = JSON.stringify({ address, size });
+    const src = this.getBlockie(key);
 
     return (
       <Badge
@@ -39,7 +41,8 @@ export default class IdentityIcon extends Component {
   }
 
   @memoize
-  getBlockie (address, size = 8) {
+  getBlockie (key) {
+    const { address, size = 8 } = JSON.parse(key);
     const src = blockies({
       seed: (address || '').toLowerCase(),
       size: 8,

--- a/content/extraction.js
+++ b/content/extraction.js
@@ -1,0 +1,122 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export const EXTRACT_TYPE_EMAIL = 'EXTRACT_TYPE_EMAIL';
+export const EXTRACT_TYPE_HANDLE = 'EXTRACT_TYPE_HANDLE';
+export const EXTRACT_TYPE_GITHUB = 'EXTRACT_TYPE_GITHUB';
+
+export const TYPES = [
+  EXTRACT_TYPE_EMAIL,
+  EXTRACT_TYPE_HANDLE,
+  EXTRACT_TYPE_GITHUB
+];
+
+export default class Extraction {
+
+  match = '';
+  priority = 0;
+  text = null;
+  type = null;
+
+  address = null;
+
+  /**
+   * Extraction constructor.
+   *
+   * @param  {String} match     - The match (eg. `foobar@gmail.com`)
+   * @param  {String} text      - The type (eg. `EXTRACT_TYPE_EMAIL`)
+   * @param  {String} type      - Optional - The text where the match is found
+   *                              (eg. `http://facebook.com/foobar`
+   *                               where the match is `foobar`)
+   * @param  {Number} priority  - Optional - The extraction priority (if multiple extractions
+   *                              for the same node, all with results, which one
+   *                              should be displayed)
+   */
+  constructor ({ match, text, type, priority }) {
+    this.match = match;
+    this.type = type;
+    this.text = text || match;
+
+    // Ok since 0 is the default priority
+    if (priority) {
+      this.priority = priority;
+    }
+  }
+
+  lookup (lookup) {
+    if (this.type === EXTRACT_TYPE_EMAIL) {
+      const email = this.match;
+
+      return lookup.email(email)
+        .then((result) => {
+          this.setAddress(result.address);
+        });
+    }
+
+    if (this.type === EXTRACT_TYPE_GITHUB) {
+      const handle = this.match;
+
+      return lookup.github(handle)
+        .then((result) => {
+          this.setAddress(result.address);
+        });
+    }
+
+    if (this.type === EXTRACT_TYPE_HANDLE) {
+      const handle = this.match;
+
+      return lookup.name(handle)
+        .then((result) => {
+          this.setAddress(result.address);
+        });
+    }
+  }
+
+  /**
+   * Set the resolved address for the current extraction
+   *
+   * @param {String} address - The resolved Ethereum Address
+   */
+  setAddress (address) {
+    if (address) {
+      this.address = address;
+    }
+  }
+
+  toObject () {
+    const { address, match, priority, type, text } = this;
+
+    const data = {
+      address, match, priority, type, text
+    };
+
+    return data;
+  }
+
+  static fromObject (data) {
+    const { address, match, priority, type, text } = data;
+    const extraction = new Extraction({
+      match, priority, type, text
+    });
+
+    if (address) {
+      extraction.setAddress(address);
+    }
+
+    return extraction;
+  }
+
+}

--- a/content/extractions.js
+++ b/content/extractions.js
@@ -60,9 +60,10 @@ export default class Extractions {
     if (href) {
       this.push(findMailto(href), { type: EXTRACT_TYPE_EMAIL, priority: 1 });
 
-      const social = Socials.extract(href);
+      const socialExtractions = Socials.extract(href);
 
-      if (social) {
+      if (socialExtractions.length) {
+        const social = socialExtractions[0];
         const match = social.name;
         const type = social.github
           ? EXTRACT_TYPE_GITHUB
@@ -88,10 +89,18 @@ export default class Extractions {
    */
   fromText (text) {
     const emails = findEmails(text);
-    // const socials = Socials.extract(text);
+    const socialExtractions = Socials.extract(text);
 
     emails.forEach((email) => {
       this.push(email, { text: email, type: EXTRACT_TYPE_EMAIL });
+    });
+
+    socialExtractions.forEach((social) => {
+      const type = social.github
+        ? EXTRACT_TYPE_GITHUB
+        : EXTRACT_TYPE_HANDLE;
+
+      this.push(social.name, { type, text: social.text });
     });
 
     return this;
@@ -120,6 +129,10 @@ export default class Extractions {
       });
 
     return extraction;
+  }
+
+  all () {
+    return this.extractions.filter((extraction) => extraction.address);
   }
 
   /**

--- a/content/extractions.js
+++ b/content/extractions.js
@@ -59,7 +59,17 @@ export default class Extractions {
 
     if (href) {
       this.push(findMailto(href), { type: EXTRACT_TYPE_EMAIL, priority: 1 });
-      // push(matches, Socials.extract(href), EXTRACT_FROM_ATTRIBUTES, EXTRACT_TYPE_EMAIL);
+
+      const social = Socials.extract(href);
+
+      if (social) {
+        const match = social.name;
+        const type = social.github
+          ? EXTRACT_TYPE_GITHUB
+          : EXTRACT_TYPE_HANDLE;
+
+        this.push(match, { type, priority: 10 });
+      }
     }
 
     // Try to find email in these DOM attributes,

--- a/content/extractions.js
+++ b/content/extractions.js
@@ -1,0 +1,196 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { uniq } from 'lodash';
+
+import Extraction, {
+  EXTRACT_TYPE_EMAIL,
+  EXTRACT_TYPE_HANDLE,
+  EXTRACT_TYPE_GITHUB
+} from './extraction';
+
+import Socials from './socials';
+
+export const TAGS_BLACKLIST = [ 'script' ];
+
+const EMAIL_PATTERN = /([^\s@]+@[^\s@]+\.[a-z]+)/i;
+const MAILTO_PATTERN = new RegExp(`mailto:${EMAIL_PATTERN.source}`, 'i');
+
+export default class Extractions {
+
+  extractions = [];
+
+  get addresses () {
+    const addresses = this.extractions
+      .map((extraction) => extraction.address)
+      .filter((address) => address);
+
+    return uniq(addresses);
+  }
+
+  map (func) {
+    return this.extractions.map(func.bind(this));
+  }
+
+  /**
+   * Extract matches from the given node's attributes
+   */
+  fromAttributes ($dom) {
+    const tag = $dom.tagName.toLowerCase();
+
+    if (!tag || TAGS_BLACKLIST.includes(tag)) {
+      return [];
+    }
+
+    const { href, email, title, alt } = $dom;
+
+    if (href) {
+      this.push(findMailto(href), { type: EXTRACT_TYPE_EMAIL, priority: 1 });
+      // push(matches, Socials.extract(href), EXTRACT_FROM_ATTRIBUTES, EXTRACT_TYPE_EMAIL);
+    }
+
+    // Try to find email in these DOM attributes,
+    // prioritizing the `email` attribute
+    [ email, alt, title ]
+      .filter((value) => value)
+      .forEach((value, index) => {
+        this.push(findEmail(value), { type: EXTRACT_TYPE_EMAIL, priority: 2 + index });
+      });
+
+    return this;
+  }
+
+  /**
+   * Extract matches from the given text
+   */
+  fromText (text) {
+    const emails = findEmails(text);
+    // const socials = Socials.extract(text);
+
+    emails.forEach((email) => {
+      this.push(email, { text: email, type: EXTRACT_TYPE_EMAIL });
+    });
+
+    return this;
+  }
+
+  /**
+   * Is the extraction list empty?
+   *
+   * @return {Boolean}
+   */
+  empty () {
+    return this.extractions.length === 0;
+  }
+
+  /**
+   * Returns the first extraction with an address
+   * (ie. a result), sorted by their priority.
+   */
+  first () {
+    const extraction = this.extractions
+      .sort((exA, exB) => {
+        return exB.priority - exA.priority;
+      })
+      .find((extraction) => {
+        return extraction.address;
+      });
+
+    return extraction;
+  }
+
+  /**
+   * Is the given match and type already included in the extractions?
+   *
+   * @return {Boolean}
+   */
+  includes (match, type) {
+    return !!this.extractions.find((extraction) => {
+      return extraction.type === type && extraction.match === match;
+    });
+  }
+
+  /**
+   * Push a new match to the extractions list, if
+   * truthy match and if not already included in
+   * the list.
+   */
+  push (match, { type, text = '', priority = 0 }) {
+    if (!match) {
+      return this;
+    }
+
+    if (this.includes(match, type)) {
+      return this;
+    }
+
+    const extraction = new Extraction({ match, text, type, priority });
+    this.extractions.push(extraction);
+
+    return this;
+  }
+
+  /**
+   * Replace the current extractions with new ones
+   */
+  replaceWith (nextExtractions) {
+    this.extractions = nextExtractions.extractions.slice();
+  }
+
+  toObject () {
+    return this.extractions.map((extraction) => extraction.toObject());
+  }
+
+  static fromObject (data) {
+    const extractions = data.map((extraction) => Extraction.fromObject(extraction));
+    const self = new Extractions();
+
+    self.extractions = extractions;
+    return self;
+  }
+
+}
+
+function findMailto (val) {
+  if (MAILTO_PATTERN.test(val)) {
+    const match = MAILTO_PATTERN.exec(val);
+    return match[1];
+  }
+
+  return null;
+}
+
+function findEmail (val) {
+  if (EMAIL_PATTERN.test(val)) {
+    const match = EMAIL_PATTERN.exec(val);
+    return match[1];
+  }
+
+  return null;
+}
+
+function findEmails (text) {
+  const regex = new RegExp(EMAIL_PATTERN.source, 'gi');
+  const emails = [];
+  let match = regex.exec(text);
+
+  while (match) {
+    emails.push(match[1]);
+    match = regex.exec(text);
+  }
+
+  return emails;
+}

--- a/content/extractions.spec.js
+++ b/content/extractions.spec.js
@@ -1,0 +1,39 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import Extractions from './extractions';
+
+import {
+  EXTRACT_TYPE_EMAIL
+} from './extraction';
+
+describe('content/extractions', () => {
+  describe('from attributes', () => {
+    const mail = 'foobar@gmail.com';
+    const dom = {
+      tagName: 'a',
+      href: `mailto:${mail}`
+    };
+
+    it('extracts mailto: href', () => {
+      const extractions = new Extractions();
+      extractions.fromAttributes(dom);
+
+      expect(extractions.empty()).toEqual(false);
+      expect(extractions.includes(mail, EXTRACT_TYPE_EMAIL)).toEqual(true);
+    });
+  });
+});

--- a/content/extractor.js
+++ b/content/extractor.js
@@ -96,26 +96,19 @@ export default class Extractor {
         continue;
       }
 
-      /** @todo  For each extraction, find ALL occurencies/safe nodes and augment them */
-      // const promise = Runner.execute(PROCESS_MATCHES, extractions.toObject())
-      //   .then((result = {}) => {
-      //     extractions.forEach((extraction) => {
-      //       const { key } = extraction;
+      const promise = Accounts.processExtractions(extractions)
+        .then(() => {
+          // Get all the matching extractions
+          return extractions.all().map((extraction) => {
+            const safeNodes = Augmentor.getSafeNodes(extraction, parentNode);
 
-      //       if (!result[key]) {
-      //         return null;
-      //       }
+            return safeNodes.map((safeNode) => {
+              return Augmentor.augmentNode(extraction, safeNode);
+            });
+          });
+        });
 
-      //       const safeNode = Augmentor.getSafeNode(key, parentNode);
-      //       parentNode = safeNode.parentElement;
-      //       return Augmentor.augmentNode(key, safeNode, result);
-      //     });
-      //   })
-      //   .catch((error) => {
-      //     console.error('extracting', node, error);
-      //   });
-
-      // promises.push(promise);
+      promises.push(promise);
     }
 
     return Promise.all(promises);

--- a/content/socials.js
+++ b/content/socials.js
@@ -16,11 +16,28 @@
 
 export default class Socials {
 
+  static extract (input) {
+    const matches = [];
+    let text = input;
+    let match = Socials.extractSingle(text);
+
+    while (match) {
+      matches.push(match);
+
+      // Re-extract from the text starting after the current match
+      const index = text.indexOf(match.name);
+      text = text.slice(index + match.name.length);
+      match = Socials.extractSingle(text);
+    }
+
+    return matches;
+  }
+
   /**
    * Tries to extract a handle from the given input based on different
    * social networks regex (facebook, github, etc...)
    */
-  static extract (input) {
+  static extractSingle (input) {
     const { all } = Socials;
 
     let match = null;
@@ -30,7 +47,7 @@ export default class Socials {
     });
 
     const blacklist = [ '/', '?', '#' ];
-    const matchBlacklist = blacklist.find((s) => match && match.includes(s));
+    const matchBlacklist = blacklist.find((s) => match && match.handle.includes(s));
 
     if (!match || matchBlacklist) {
       return null;
@@ -38,7 +55,7 @@ export default class Socials {
 
     // Return the handle from the RegExp matcher
     const extras = social.extras || {};
-    return { name: match, ...extras };
+    return { name: match.handle, text: match.text, ...extras };
   }
 
   static get all () {
@@ -58,7 +75,7 @@ export default class Socials {
     ];
 
     const blacklistRegexp = blacklist.join('|');
-    const matcher = new RegExp(`/(?:https?://)?(?:www.)?github.(?:[a-z]+)/(?!(${blacklistRegexp}))([^\\s]+)`, 'i');
+    const matcher = new RegExp(`(?:https?://)?(?:www.)?github.(?:[a-z]+)/(?!(${blacklistRegexp}))([^\\s]+)`, 'i');
 
     return {
       match: (input) => {
@@ -67,7 +84,7 @@ export default class Socials {
         }
 
         const matches = matcher.exec(input);
-        return matches[2];
+        return { handle: matches[2], text: matches[0] };
       },
       extras: { github: true }
     };
@@ -83,7 +100,7 @@ export default class Socials {
         }
 
         const matches = matcher.exec(input);
-        return matches[1];
+        return { handle: matches[1], text: matches[0] };
       }
     };
   }
@@ -98,7 +115,7 @@ export default class Socials {
         }
 
         const matches = matcher.exec(input);
-        return matches[1];
+        return { handle: matches[1], text: matches[0] };
       }
     };
   }
@@ -113,7 +130,7 @@ export default class Socials {
         }
 
         const matches = matcher.exec(input);
-        return matches[1];
+        return { handle: matches[1], text: matches[0] };
       }
     };
   }

--- a/content/socials.spec.js
+++ b/content/socials.spec.js
@@ -19,6 +19,25 @@ import Socials from './socials';
 describe('content/socials', () => {
   const { all } = Socials;
 
+  describe('extracts', () => {
+    const single = 'There is https://github.com/foobar';
+    const multiple = 'There is https://github.com/foobar and https://github.com/foobaz';
+
+    it('multiple matches', () => {
+      const matches = Socials.extract(multiple);
+
+      expect(matches.length).toEqual(2);
+      expect(matches[0].name).toEqual('foobar');
+      expect(matches[0].text).toEqual('https://github.com/foobar');
+    });
+
+    it('single match', () => {
+      const matches = Socials.extract(single);
+
+      expect(matches.length).toEqual(1);
+    });
+  });
+
   describe('github', () => {
     const rightInput = 'https://github.com/foobar';
     const wrongInput = 'https://githubwe.com/foobar';
@@ -28,15 +47,16 @@ describe('content/socials', () => {
     });
 
     it('extracts the correct handle', () => {
-      expect(Socials.extract(rightInput).name).toEqual('foobar');
+      expect(Socials.extractSingle(rightInput).name).toEqual('foobar');
+      expect(Socials.extractSingle(rightInput).text).toEqual(rightInput);
     });
 
     it('contains extras', () => {
-      expect(Socials.extract(rightInput)).toEqual({ name: 'foobar', github: true });
+      expect(Socials.extractSingle(rightInput)).toEqual({ name: 'foobar', text: rightInput, github: true });
     });
 
     it('fails correctly', () => {
-      expect(Socials.extract(wrongInput)).toBeNull();
+      expect(Socials.extractSingle(wrongInput)).toBeNull();
     });
 
     it('does not extract default links', () => {
@@ -50,7 +70,7 @@ describe('content/socials', () => {
       ];
 
       links.forEach((link) => {
-        expect(Socials.extract(link)).toBeNull();
+        expect(Socials.extractSingle(link)).toBeNull();
       });
     });
 
@@ -63,7 +83,7 @@ describe('content/socials', () => {
       ];
 
       links.forEach((link) => {
-        expect(Socials.extract(link)).toBeNull();
+        expect(Socials.extractSingle(link)).toBeNull();
       });
     });
   });
@@ -77,11 +97,11 @@ describe('content/socials', () => {
     });
 
     it('extracts the correct handle', () => {
-      expect(Socials.extract(rightInput)).toEqual({ name: 'foobar' });
+      expect(Socials.extractSingle(rightInput)).toEqual({ name: 'foobar', text: rightInput });
     });
 
     it('fails correctly', () => {
-      expect(Socials.extract(wrongInput)).toBeNull();
+      expect(Socials.extractSingle(wrongInput)).toBeNull();
     });
   });
 
@@ -94,11 +114,11 @@ describe('content/socials', () => {
     });
 
     it('extracts the correct handle', () => {
-      expect(Socials.extract(rightInput)).toEqual({ name: 'foobar' });
+      expect(Socials.extractSingle(rightInput)).toEqual({ name: 'foobar', text: rightInput });
     });
 
     it('fails correctly', () => {
-      expect(Socials.extract(wrongInput)).toBeNull();
+      expect(Socials.extractSingle(wrongInput)).toBeNull();
     });
   });
 
@@ -111,11 +131,11 @@ describe('content/socials', () => {
     });
 
     it('extracts the correct handle', () => {
-      expect(Socials.extract(rightInput)).toEqual({ name: 'foobar' });
+      expect(Socials.extractSingle(rightInput)).toEqual({ name: 'foobar', text: rightInput });
     });
 
     it('fails correctly', () => {
-      expect(Socials.extract(wrongInput)).toBeNull();
+      expect(Socials.extractSingle(wrongInput)).toBeNull();
     });
   });
 });

--- a/content/styles.css
+++ b/content/styles.css
@@ -17,14 +17,16 @@
 
 @import url('https://fonts.googleapis.com/css?family=Roboto:300');
 
-.transition {
-  transition-property: opacity, transform, z-index;
-  transition-duration: 0.25s;
-  transition-timing-function: cubic-bezier(0.7,0,0.3,1);
+:root {
+  --transition-property: opacity, transform, z-index;
+  --transition-duration: 0.25s;
+  --transition-timing-function: cubic-bezier(0.7,0,0.3,1);
 }
 
 .container {
-  composes: transition;
+  transition-property: var(--transition-property);
+  transition-duration: var(--transition-duration);
+  transition-timing-function: var(--transition-timing-function);
 
   display: inline-flex !important;
   flex-direction: row !important;

--- a/package.json
+++ b/package.json
@@ -48,6 +48,8 @@
     "html-loader": "^0.4.4",
     "husky": "^0.12.0",
     "jest": "^18.1.0",
+    "postcss-autoreset": "^1.2.1",
+    "postcss-css-variables": "^0.6.0",
     "postcss-import": "^9.1.0",
     "postcss-loader": "^1.2.2",
     "postcss-nested": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "postcss-import": "^9.1.0",
     "postcss-loader": "^1.2.2",
     "postcss-nested": "^1.0.0",
-    "postcss-simple-vars": "^3.0.0",
     "progress-bar-webpack-plugin": "^1.9.3",
     "rucksack-css": "^0.9.1",
     "style-loader": "^0.13.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,7 +22,6 @@ const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 const postcssImport = require('postcss-import');
 const postcssNested = require('postcss-nested');
 const postcssAutoreset = require('postcss-autoreset');
-const postcssVars = require('postcss-simple-vars');
 const postcssVariables = require('postcss-css-variables');
 const rucksack = require('rucksack-css');
 
@@ -43,11 +42,6 @@ const postcss = [
   postcssNested({}),
   postcssAutoreset({
     rulesMatcher: (rule) => !rule.selector.match(/(hover|open|icon|\*)/)
-  }),
-  postcssVars({
-    unknown: function (node, name, result) {
-      node.warn(result, `Unknown variable ${name}`);
-    }
   }),
   postcssVariables({}),
   rucksack({

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,7 +21,9 @@ const ProgressBarPlugin = require('progress-bar-webpack-plugin');
 
 const postcssImport = require('postcss-import');
 const postcssNested = require('postcss-nested');
+const postcssAutoreset = require('postcss-autoreset');
 const postcssVars = require('postcss-simple-vars');
+const postcssVariables = require('postcss-css-variables');
 const rucksack = require('rucksack-css');
 
 const Shared = require('./scripts/shared');
@@ -39,11 +41,15 @@ const postcss = [
     addDependencyTo: webpack
   }),
   postcssNested({}),
+  postcssAutoreset({
+    rulesMatcher: (rule) => !rule.selector.match(/(hover|open|icon|\*)/)
+  }),
   postcssVars({
     unknown: function (node, name, result) {
       node.warn(result, `Unknown variable ${name}`);
     }
   }),
+  postcssVariables({}),
   rucksack({
     autoprefixer: true
   })

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -41,7 +41,7 @@ const postcss = [
   }),
   postcssNested({}),
   postcssAutoreset({
-    rulesMatcher: (rule) => !rule.selector.match(/(hover|open|icon|\*)/)
+    rulesMatcher: (rule) => !rule.selector.match(/(hover|open|icon|root|\*)/)
   }),
   postcssVariables({}),
   rucksack({


### PR DESCRIPTION
Closes #22 

It displays black and white info on matches that are unsafe/not trusted/verified.
Also refactored how extraction is handled to make it easier now.

It improves the overall extraction ; now it can match multiple emails/handles/etc. in a single text element.