### PR TITLE
Add a full Web3 instance only if needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "postcss-loader": "1.2.2",
     "postcss-nested": "1.0.0",
     "progress-bar-webpack-plugin": "1.9.3",
+    "raw-loader": "0.5.1",
     "rucksack-css": "0.9.1",
     "style-loader": "0.13.1",
     "webpack": "2.2.1"

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "material-design-lite": "1.3.0",
     "preact": "7.1.0",
     "preact-mdl": "2.2.0",
-    "preact-portal": "1.1.1"
+    "preact-portal": "1.1.1",
+    "web3": "0.18.2"
   }
 }

--- a/web3/inpage.js
+++ b/web3/inpage.js
@@ -168,6 +168,8 @@ if (!window.chrome || !window.chrome.extension) {
       // Else, add a full web3 instance
       if (!web3.injectedWeb3) {
         const Web3 = require('web3/lib/web3');
+
+        window.Web3 = Web3;
         web3.injectedWeb3 = new Web3(web3.currentProvider);
       }
 

--- a/web3/inpage.js
+++ b/web3/inpage.js
@@ -167,10 +167,11 @@ if (!window.chrome || !window.chrome.extension) {
 
       // Else, add a full web3 instance
       if (!web3.injectedWeb3) {
-        const Web3 = require('web3/lib/web3');
+        const rawWeb3 = require('web3/dist/web3.min.js');
+        eval(rawWeb3); // eslint-disable-line no-eval
 
-        window.Web3 = Web3;
-        web3.injectedWeb3 = new Web3(web3.currentProvider);
+        web3.injectedWeb3 = new window.Web3(web3.currentProvider);
+        window.web3 = proxiedWeb3;
       }
 
       // And return the value from this web3 instance

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,6 +74,10 @@ module.exports = {
   module: {
     rules: [
       {
+        test: /node_modules\/web3.+\.js$/,
+        use: 'raw-loader'
+      },
+      {
         test: /\.js$/,
         exclude: /(node_modules)/,
         use: 'babel-loader'


### PR DESCRIPTION
Fixes #50 

Add a proxy to the Window `web3` object. If the page tries to get a property from that have no value (so something else than `currentProvider` and the `Object.prototype` value), it loads Web3, create a new instance, and return the value from this instance.

@tomusdrw Not sure if we should restrain this trigger to only the know web3 keys (`eth`, `db`, `net`, etc.) or not ?