### PR TITLE
Update create-chrome-extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-runtime": "6.22.0",
     "case-sensitive-paths-webpack-plugin": "1.1.4",
     "chai": "3.5.0",
-    "chrome-extension-utils": "https://github.com/ngotchac/create-chrome-extension.git#d54972f2bf869f207e45f82b5c53b1559d911602",
+    "chrome-extension-utils": "https://github.com/ngotchac/create-chrome-extension.git#bba361b70aae1286a7ce44ff674bb96b5285bf20",
     "css-loader": "0.26.1",
     "eslint": "3.15.0",
     "eslint-config-semistandard": "7.0.0",


### PR DESCRIPTION
I ran into [this](https://stackoverflow.com/questions/42759936/strange-error-in-selenium-after-upgrading-to-chromedriver-2-28-needed-for-chrome) issue trying to build the extension.

The solution is just adding the `--disable-gpu` flag when running Chrome to build the extension (see https://github.com/ngotchac/create-chrome-extension/commit/e012a094bdadce01a2780684fbe69ad7861d3029)